### PR TITLE
Check if field name exists

### DIFF
--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -26,8 +26,11 @@ class RevisionHistory extends FormWidgetBase
         $this->vars['history'] = $this->model->revision_history->reverse();
         $this->vars['getFieldName'] = function ($fieldName) {
             $fields = $this->parentForm->getFields();
-            $field = $fields[$fieldName];
-            return $field->label ?? $field->tab ?? $fieldName;
+            if (array_key_exists($fieldName, $fields)) {
+                $field = $fields[$fieldName];
+                return $field->label ?? $field->tab ?? $fieldName;
+            }
+            return $fieldName;
         };
     }
 


### PR DESCRIPTION
I'm using revisionable on a relation field. The getFieldName function doesn't breaks in this case because it looks for the fieldName with `_id` added.