### PR TITLE
Group revisions by created_at and user

### DIFF
--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -23,7 +23,12 @@ class RevisionHistory extends FormWidgetBase
 
     public function prepareVars()
     {
-        $this->vars['history'] = $this->model->revision_history->reverse();
+        $revisionHistory = $this->model->revision_history->reverse();
+        $histories = [];
+        foreach ($revisionHistory as $history) {
+            $histories[$history->created_at . $history->user_id][] = $history;
+        }
+        $this->vars['histories'] = $histories;
         $this->vars['getFieldName'] = function ($fieldName) {
             $fields = $this->parentForm->getFields();
             if (array_key_exists($fieldName, $fields)) {
@@ -51,8 +56,12 @@ class RevisionHistory extends FormWidgetBase
         $section = $modelClass::find($this->model->id);
 
         $revision = Revision::find(input('revision_id'));
+        $revisions = Revision::where('user_id', $revision->user_id)->where('created_at', $revision->created_at)->get();
 
-        $section->{$revision->field} = $revision->old_value;
+        foreach ($revisions as $revision) {
+            $section->{$revision->field} = $revision->old_value;
+        }
+
         $section->save();
 
         Flash::success('Changes have been restored, changes are not visible without refreshing the page.');

--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -56,7 +56,14 @@ class RevisionHistory extends FormWidgetBase
         $section = $modelClass::find($this->model->id);
 
         $revision = Revision::find(input('revision_id'));
-        $revisions = Revision::where('user_id', $revision->user_id)->where('created_at', $revision->created_at)->get();
+
+        if (input('restore_all')) {
+            $revisions = Revision::where('user_id', $revision->user_id)->where('created_at', $revision->created_at)->get();
+        } else {
+            $revisionIds = input('checkbox_' . $revision->id);
+            error_log(print_r($revisionIds, 1));
+            $revisions = Revision::find($revisionIds);
+        }
 
         foreach ($revisions as $revision) {
             $section->{$revision->field} = $revision->old_value;

--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -61,7 +61,6 @@ class RevisionHistory extends FormWidgetBase
             $revisions = Revision::where('user_id', $revision->user_id)->where('created_at', $revision->created_at)->get();
         } else {
             $revisionIds = input('checkbox_' . $revision->id);
-            error_log(print_r($revisionIds, 1));
             $revisions = Revision::find($revisionIds);
         }
 

--- a/formwidgets/revisionhistory/partials/_revisionhistory.htm
+++ b/formwidgets/revisionhistory/partials/_revisionhistory.htm
@@ -1,55 +1,60 @@
 <div class="revision_history">
     <ul>
-        <?php foreach ($history as $record) { ?>
-        <li>
-            <a data-toggle="modal" href="#history-revision-<?= $record->id ?>">
-                <i class="list-icon icon-terminal"></i>
-                <span class="title"><?= $record->created_at->format('d. m. Y H:i') ?></span>
-                <span class="description-user">
-                    <?php if ($record->user) { ?>
-                        <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
-                    <?php }else{ ?>
-                        System
+        <?php foreach ($histories as $history) { ?>
+            <?php $record = array_first($history) ?>
+            <li>
+                <a data-toggle="modal" href="#history-revision-<?= $record->id ?>">
+                    <i class="list-icon icon-terminal"></i>
+                    <span class="title"><?= $record->created_at->format('d. m. Y H:i') ?></span>
+                    <span class="description-user">
+                        <?php if ($record->user) { ?>
+                            <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
+                        <?php }else{ ?>
+                            System
+                        <?php } ?>
+                    </span>
+                    <?php foreach($history as $change) { ?>
+                    <span class="description">
+                        <?= e(trans($getFieldName($change->field))) ?>:
+                        <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($change->old_value), e($change->new_value)) ?>
+                    </span>
                     <?php } ?>
-                </span>
-                <span class="description">
-                    <?= e(trans($getFieldName($record->field))) ?>:
-                    <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($record->old_value), e($record->new_value)) ?>
-                </span>
-                <span class="borders"></span>
-            </a>
+                    <span class="borders"></span>
+                </a>
 
-            <div class="control-popup modal fade" id="history-revision-<?= $record->id ?>" tabindex="-1"
-                role="dialog">
-                <div class="modal-dialog">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                            <h4 class="modal-title">Restore change</h4>
-                        </div>
-                        <div class="modal-body">
-                            <p>
-                                <?php if ($record->user) { ?>
-                                    <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
-                                <?php } else { ?>
-                                    System
+                <div class="control-popup modal fade" id="history-revision-<?= $record->id ?>" tabindex="-1"
+                    role="dialog">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                                <h4 class="modal-title">Restore change</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>
+                                    <?php if ($record->user) { ?>
+                                        <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
+                                    <?php } else { ?>
+                                        System
+                                    <?php } ?>
+                                </p>
+                                <?php foreach($history as $change) { ?>
+                                    <h5><?= e(trans($getFieldName($change->field))) ?>:</h5>
+                                    <p>
+                                        <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($record->old_value), e($change->new_value)) ?>
+                                    </p>
                                 <?php } ?>
-                            </p>
-                            <h5><?= e(trans($getFieldName($record->field))) ?>:</h5>
-                            <p>
-                                <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($record->old_value), e($record->new_value)) ?>
-                            </p>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="submit" class="btn btn-primary" data-request="onRevertHistory"
-                                data-request-data="revision_id: <?= $record->id ?>" data-request-flash
-                                data-dismiss="modal">Restore change</button>
-                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="submit" class="btn btn-primary" data-request="onRevertHistory"
+                                    data-request-data="revision_id: <?= $record->id ?>" data-request-flash
+                                    data-dismiss="modal">Restore change</button>
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </li>
+            </li>
         <?php } ?>
     </ul>
 </div>

--- a/formwidgets/revisionhistory/partials/_revisionhistory.htm
+++ b/formwidgets/revisionhistory/partials/_revisionhistory.htm
@@ -1,60 +1,73 @@
 <div class="revision_history">
     <ul>
         <?php foreach ($histories as $history) { ?>
-            <?php $record = array_first($history) ?>
-            <li>
-                <a data-toggle="modal" href="#history-revision-<?= $record->id ?>">
-                    <i class="list-icon icon-terminal"></i>
-                    <span class="title"><?= $record->created_at->format('d. m. Y H:i') ?></span>
-                    <span class="description-user">
+        <?php $record = array_first($history) ?>
+        <li>
+            <a data-toggle="modal" href="#history-revision-<?= $record->id ?>">
+                <i class="list-icon icon-terminal"></i>
+                <span class="title"><?= $record->created_at->format('d. m. Y H:i') ?></span>
+                <span class="description-user">
                         <?php if ($record->user) { ?>
-                            <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
-                        <?php }else{ ?>
-                            System
-                        <?php } ?>
-                    </span>
-                    <?php foreach($history as $change) { ?>
-                    <span class="description">
-                        <?= e(trans($getFieldName($change->field))) ?>:
-                        <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($change->old_value), e($change->new_value)) ?>
-                    </span>
+                    <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
+                    <?php }else{ ?>
+                    System
                     <?php } ?>
-                    <span class="borders"></span>
-                </a>
+                    </span>
+                <?php foreach($history as $change) { ?>
+                <span class="description">
+                        <?= e(trans($getFieldName($change->field))) ?>:
+                    <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($change->old_value), e($change->new_value)) ?>
+                    </span>
+                <?php } ?>
+                <span class="borders"></span>
+            </a>
 
-                <div class="control-popup modal fade" id="history-revision-<?= $record->id ?>" tabindex="-1"
-                    role="dialog">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title">Restore change</h4>
-                            </div>
-                            <div class="modal-body">
-                                <p>
-                                    <?php if ($record->user) { ?>
-                                        <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
-                                    <?php } else { ?>
-                                        System
-                                    <?php } ?>
-                                </p>
-                                <?php foreach($history as $change) { ?>
-                                    <h5><?= e(trans($getFieldName($change->field))) ?>:</h5>
-                                    <p>
+            <div class="control-popup modal fade" id="history-revision-<?= $record->id ?>" tabindex="-1"
+                 role="dialog">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal-title">Restore selected changes</h4>
+                        </div>
+                        <div class="modal-body">
+                            <p>
+                                <?php if ($record->user) { ?>
+                                <?= e($record->user->first_name) ?> <?= e($record->user->last_name) ?>
+                                <?php } else { ?>
+                                System
+                                <?php } ?>
+                            </p>
+
+
+                            <?php foreach($history as $change) { ?>
+                            <div class="form-group checkbox-field is-required">
+                                <div class="checkbox custom-checkbox">
+                                    <input name="checkbox_<?= $record->id ?>[]" value="<?= $change->id ?>" type="checkbox"
+                                           id="checkbox_<?= $change->id ?>" checked>
+                                    <label for="checkbox_<?= $change->id ?>"><?= e(trans($getFieldName($change->field))) ?></label>
+                                    <p class="help-block">
                                         <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($record->old_value), e($change->new_value)) ?>
                                     </p>
-                                <?php } ?>
+                                </div>
                             </div>
-                            <div class="modal-footer">
-                                <button type="submit" class="btn btn-primary" data-request="onRevertHistory"
-                                    data-request-data="revision_id: <?= $record->id ?>" data-request-flash
-                                    data-dismiss="modal">Restore change</button>
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                            </div>
+                            <?php } ?>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="submit" class="btn btn-primary" data-request="onRevertHistory"
+                                    data-request-data="restore_all:0,revision_id:<?= $record->id ?>"
+                                    data-request-flash data-dismiss="modal">Restore selected changes
+                            </button>
+                            <button type="submit" class="btn btn-info" data-request="onRevertHistory"
+                                    data-request-data="restore_all:1,revision_id:<?= $record->id ?>"
+                                    data-request-flash data-dismiss="modal">Restore all changes
+                            </button>
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                         </div>
                     </div>
                 </div>
-            </li>
+            </div>
+        </li>
         <?php } ?>
     </ul>
 </div>


### PR DESCRIPTION
Grouping all changes by user and timestamp seems more logical. 

We talked about this on Slack about a month ago. Let me know what you think.