### PR TITLE
Add missing translation

### DIFF
--- a/formwidgets/revisionhistory/partials/_revisionhistory.htm
+++ b/formwidgets/revisionhistory/partials/_revisionhistory.htm
@@ -29,7 +29,7 @@
 
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title">Restore selected changes</h4>
+                                <h4 class="modal-title"><?= e(trans('samuell.revisions::lang.revision.restore')) ?></h4>
                             </div>
 
                             <form id="revision-form-<?= $record->id ?>"


### PR DESCRIPTION
I think a translation string got lost in a merge conflict. This PR rolls that back.