### PR TITLE
Add readOnly option to widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ history:
     disabled: true
     type: revisionhistory
     recordsPerPage: 10
+    readOnly: false
 ```

--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -18,6 +18,7 @@ use Lang;
 class RevisionHistory extends FormWidgetBase
 {
     public $recordsPerPage = null;
+    public $readOnly = null;
 
     protected $defaultAlias = 'samuell_revisions_revision_history';
     protected $distinctRevisions;
@@ -28,6 +29,7 @@ class RevisionHistory extends FormWidgetBase
     {
         $this->fillFromConfig([
             'recordsPerPage',
+            'readOnly',
         ]);
 
         $this->showPagination = $this->recordsPerPage && $this->recordsPerPage > 0;
@@ -75,6 +77,11 @@ class RevisionHistory extends FormWidgetBase
 
     public function onRevertHistory()
     {
+        if ($this->readOnly) {
+            Flash::error(Lang::get('samuell.revisions::lang.revision.read_only_error'));
+            return;
+        }
+
         $this->validateInput();
 
         $modelClass = $this->getClass();

--- a/formwidgets/revisionhistory/partials/_revisionhistory.htm
+++ b/formwidgets/revisionhistory/partials/_revisionhistory.htm
@@ -29,7 +29,13 @@
 
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title"><?= e(trans('samuell.revisions::lang.revision.restore')) ?></h4>
+                                <h4 class="modal-title">
+                                    <?php if ($this->readOnly) { ?>
+                                        <?= e(trans('samuell.revisions::lang.revision.view')) ?>
+                                    <?php } else { ?>
+                                        <?= e(trans('samuell.revisions::lang.revision.restore')) ?>
+                                    <?php } ?>
+                                </h4>
                             </div>
 
                             <form id="revision-form-<?= $record->id ?>"
@@ -47,11 +53,17 @@
                                         <?php } ?>
                                     </p>
 
+                                    <p>
+                                        <?= $record->created_at->locale(Lang::getLocale())->isoFormat('LLL') ?>
+                                    </p>
+
                                     <?php foreach($revisions as $revision) { ?>
                                         <div class="form-group checkbox-field is-required">
-                                            <div class="checkbox custom-checkbox">
-                                                <input name="revisions[]" value="<?= $revision->id ?>"
-                                                       type="checkbox" id="checkbox_<?= $revision->id ?>" checked>
+                                            <div class="<?= $this->readOnly ? '' : 'checkbox custom-checkbox' ?>">
+                                                <?php if (!$this->readOnly) { ?>
+                                                    <input name="revisions[]" value="<?= $revision->id ?>"
+                                                           type="checkbox" id="checkbox_<?= $revision->id ?>" checked>
+                                                <?php } ?>
                                                 <label for="checkbox_<?= $revision->id ?>">
                                                     <?= e(trans($getFieldName($revision->field))) ?>
                                                 </label>
@@ -65,18 +77,24 @@
                             </form>
 
                             <div class="modal-footer">
-                                <button type="submit" class="btn btn-primary"
-                                        form="revision-form-<?= $record->id ?>">
-                                    <?= e(trans('samuell.revisions::lang.revision.restore_selected')) ?>
-                                </button>
-                                <button class="btn btn-info" data-request="onRevertHistory"
-                                        data-request-data="restore_all:1,revision_id:<?= $record->id ?>"
-                                        data-request-flash
-                                        data-request-success="$(this).closest('.modal').modal('hide');">
-                                    <?= e(trans('samuell.revisions::lang.revision.restore_all')) ?>
-                                </button>
+                                <?php if (!$this->readOnly) { ?>
+                                    <button type="submit" class="btn btn-primary"
+                                            form="revision-form-<?= $record->id ?>">
+                                        <?= e(trans('samuell.revisions::lang.revision.restore_selected')) ?>
+                                    </button>
+                                    <button class="btn btn-info" data-request="onRevertHistory"
+                                            data-request-data="restore_all:1,revision_id:<?= $record->id ?>"
+                                            data-request-flash
+                                            data-request-success="$(this).closest('.modal').modal('hide');">
+                                        <?= e(trans('samuell.revisions::lang.revision.restore_all')) ?>
+                                    </button>
+                                <?php } ?>
                                 <button type="button" class="btn btn-default" data-dismiss="modal">
-                                    <?= e(trans('backend::lang.form.cancel')) ?>
+                                    <?php if ($this->readOnly) { ?>
+                                        <?= e(trans('backend::lang.form.close')) ?>
+                                    <?php } else { ?>
+                                        <?= e(trans('backend::lang.form.cancel')) ?>
+                                    <?php } ?>
                                 </button>
                             </div>
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -4,8 +4,10 @@ return [
     'revision' => [
         'system_user' => 'System',
         'restore' => 'Restore changes',
+        'view' => 'View changes',
         'restore_selected' => 'Restore selected changes',
         'restore_all' => 'Restore all changes',
         'changes_restored' => 'Changes have been restored, changes are not visible without refreshing the page.',
-    ]
+        'read_only_error' => 'Revisions are set to read only and can not be restored!',
+    ],
 ];

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -4,8 +4,10 @@ return [
     'revision' => [
         'system_user' => 'Systeem',
         'restore' => 'Wijzigingen terugdraaien',
+        'view' => 'Wijzigingen bekijken',
         'restore_selected' => 'Draai geselecteerde terug',
         'restore_all' => 'Draai alle terug',
         'changes_restored' => 'De wijzigingen zijn teruggedraaid, wijzigingen zijn niet zichtbaar zonder de pagina te verversen.',
+        'read_only_error' => 'Wijzigingen kunnen alleen gelezen en niet teruggedraaid worden!',
     ],
 ];


### PR DESCRIPTION
This pull request adds the option to make the widget read-only. All revisions can be viewed but none can be restored.

I also added the date of the revision to the popup.