### PR TITLE
Relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Revisions allows to extend any model with Revisionable trait. They offer more fe
 Extends OctoberCMS core trait Revisionable: https://octobercms.com/docs/database/traits#revisionable
 
 
+https://octobercms.com/plugin/samuell-revisions
+
 ## Usage
 
 Extending model with Revisions trait.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://octobercms.com/plugin/samuell-revisions
 ## Usage
 
 Extending model with Revisions trait.
-```
+```php
 class MyModel {
     use \Samuell\Revisions\Traits\Revisions;
 
@@ -24,11 +24,23 @@ class MyModel {
 
 Adding new widget to our form config
 
-```
+```yaml
 history:
     label: History of changes
     span: full
     disabled: true
     type: revisionhistory
     recordsPerPage: 10
+```
+
+### Displaying a changed relation
+
+By default, when you make a relation revisionable, only the changed ID will be displayed.
+To display the title or name of the relation instead, you can add the field below to the parent form.
+```yaml
+category_id:
+    hidden: true
+    revisions:
+        relation: Acme\Plugin\Models\Category
+        nameFrom: name # 'name' is the default
 ```

--- a/formwidgets/revisionhistory/partials/_revisionhistory.htm
+++ b/formwidgets/revisionhistory/partials/_revisionhistory.htm
@@ -16,7 +16,7 @@
                     <?php foreach($revisions as $revision) { ?>
                         <span class="description">
                             <?= e(trans($getFieldName($revision->field))) ?>:
-                            <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($revision->old_value), e($revision->new_value)) ?>
+                            <?= $getFieldDiff($revision->field, e($revision->old_value), e($revision->new_value)) ?>
                         </span>
                     <?php } ?>
                     <span class="borders"></span>
@@ -56,7 +56,7 @@
                                                     <?= e(trans($getFieldName($revision->field))) ?>
                                                 </label>
                                                 <p class="help-block">
-                                                    <?= \Samuell\Revisions\Classes\Diff::htmlDiff(e($revision->old_value), e($revision->new_value)) ?>
+                                                    <?= $getFieldDiff($revision->field, e($revision->old_value), e($revision->new_value)) ?>
                                                 </p>
                                             </div>
                                         </div>


### PR DESCRIPTION
By default, when you make a relation revisionable, only the changed ID will be displayed.
This PR adds the ability to specify the relation model and what field to display in the diff.