### PR TITLE
Display the title  a changed checkboxlist or radio

### DIFF
--- a/formwidgets/RevisionHistory.php
+++ b/formwidgets/RevisionHistory.php
@@ -177,6 +177,9 @@ class RevisionHistory extends FormWidgetBase
             if (isset($field->config['type']) && $field->config['type'] === 'switch') {
                 return $this->getBooleanDiff($field, $oldValue, $newValue);
             }
+            if (isset($field->config['options']) ) {
+                return $this->getOptionsDiff($field, $oldValue, $newValue);
+            }
         }
         return Diff::htmlDiff(e($oldValue), e($newValue));
     }
@@ -207,6 +210,28 @@ class RevisionHistory extends FormWidgetBase
             : Lang::get('backend::lang.form.field_off');
         $oldValue = $oldValue ? $onLabel : $offLabel;
         $newValue = $newValue ? $onLabel : $offLabel;
+        return Diff::htmlDiff(e($oldValue), e($newValue));
+    }
+    
+    private function getOptionsDiff($field, $oldValue, $newValue)
+    {
+        $optionConfig = $field->config['options']; 
+
+        $oldValue = explode(",",preg_replace("/[^,.0-9]/", '', $oldValue));
+        $newValue = explode(",",preg_replace("/[^,.0-9]/", '', $newValue));
+        $old ='';
+        $new =''; 
+        
+        foreach ($oldValue as $item){ 
+            $old .= isset($optionConfig[$item]) ? $optionConfig[$item].' • ' : '' ;  
+        } 
+        foreach ($newValue as $item){   
+            $new .= isset($optionConfig[$item]) ? $optionConfig[$item].' • ' : '' ;  
+        } 
+         
+        $oldValue = $old;
+        $newValue = $new; 
+        
         return Diff::htmlDiff(e($oldValue), e($newValue));
     }
 


### PR DESCRIPTION
By default, when hen you make a checkboxlist or radio revisionable, only the changed ID will be displayed.

![image](https://user-images.githubusercontent.com/41994233/113492393-b75ee700-94df-11eb-8e05-2d15d2eb9001.png)
![image](https://user-images.githubusercontent.com/41994233/113492404-c5ad0300-94df-11eb-95dc-cc0aeeed14bb.png)
